### PR TITLE
feat(editor): multi-tab scripts, diff view, undo/redo, and snippets

### DIFF
--- a/src/app/chat/page.tsx
+++ b/src/app/chat/page.tsx
@@ -35,6 +35,7 @@ const ACTION_BUTTONS = [
 export default function ChatPage() {
   const [hasSettings, setHasSettings] = useState<boolean | null>(null);
   const [pineVersion, setPineVersion] = useState<PineVersion>("v6");
+  const [uploadContext, setUploadContext] = useState<{ filename: string } | null>(null);
 
   const {
     messages,
@@ -65,7 +66,17 @@ export default function ChatPage() {
 
   const handleNewChat = useCallback(() => {
     clearChat();
+    setUploadContext(null);
   }, [clearChat]);
+
+  const handleUpload = useCallback((code: string, filename: string) => {
+    updateCode(code);
+    setUploadContext({ filename });
+  }, [updateCode]);
+
+  const handleDismissUpload = useCallback(() => {
+    setUploadContext(null);
+  }, []);
 
   const checkSettings = useCallback(() => {
     const stored = localStorage.getItem(STORAGE_KEY);
@@ -139,7 +150,13 @@ export default function ChatPage() {
                   ))}
                 </div>
 
-                <ChatInput onSend={sendMessage} disabled={isStreaming} />
+                <ChatInput
+                  onSend={sendMessage}
+                  onUpload={handleUpload}
+                  uploadContext={uploadContext}
+                  onDismissUpload={handleDismissUpload}
+                  disabled={isStreaming}
+                />
               </div>
             </div>
           ) : (
@@ -159,6 +176,9 @@ export default function ChatPage() {
               {/* Input */}
               <ChatInput
                 onSend={sendMessage}
+                onUpload={handleUpload}
+                uploadContext={uploadContext}
+                onDismissUpload={handleDismissUpload}
                 disabled={isStreaming}
                 placeholder={hasCode ? "Ask for modifications..." : undefined}
               />

--- a/src/app/chat/page.tsx
+++ b/src/app/chat/page.tsx
@@ -46,12 +46,20 @@ export default function ChatPage() {
     error,
     validationResults,
     correctedCode,
+    preCorrectCode,
+    tabs,
+    activeTabId,
     sendMessage,
     fixCode,
     loadChat,
     clearChat,
     clearCode,
     updateCode,
+    closeTab,
+    setActiveTab,
+    reorderTabs,
+    acceptCorrection,
+    rejectCorrection,
   } = useChat();
 
   const hasCode = currentCode.length > 0;
@@ -197,8 +205,16 @@ export default function ChatPage() {
               onClear={clearCode}
               validationResults={validationResults}
               correctedCode={correctedCode}
+              preCorrectCode={preCorrectCode}
               streamStatus={streamStatus}
               onFix={fixCode}
+              tabs={tabs}
+              activeTabId={activeTabId}
+              onTabSelect={setActiveTab}
+              onTabClose={closeTab}
+              onTabReorder={reorderTabs}
+              onAcceptCorrection={acceptCorrection}
+              onRejectCorrection={rejectCorrection}
             />
           </div>
         )}

--- a/src/components/chat/ChatInput.tsx
+++ b/src/components/chat/ChatInput.tsx
@@ -1,17 +1,30 @@
 "use client";
 
 import { useState, useRef, useCallback, useEffect } from "react";
-import { ArrowUp } from "lucide-react";
+import { ArrowUp, Paperclip, X } from "lucide-react";
 
 interface ChatInputProps {
   onSend: (message: string) => void;
+  onUpload?: (code: string, filename: string) => void;
+  uploadContext?: { filename: string } | null;
+  onDismissUpload?: () => void;
   disabled?: boolean;
   placeholder?: string;
 }
 
-export default function ChatInput({ onSend, disabled, placeholder }: ChatInputProps) {
+export default function ChatInput({
+  onSend,
+  onUpload,
+  uploadContext,
+  onDismissUpload,
+  disabled,
+  placeholder,
+}: ChatInputProps) {
   const [value, setValue] = useState("");
+  const [isDragging, setIsDragging] = useState(false);
   const textareaRef = useRef<HTMLTextAreaElement>(null);
+  const fileInputRef = useRef<HTMLInputElement>(null);
+  const dragCounterRef = useRef(0);
 
   const resize = useCallback(() => {
     const el = textareaRef.current;
@@ -24,11 +37,23 @@ export default function ChatInput({ onSend, disabled, placeholder }: ChatInputPr
     resize();
   }, [value, resize]);
 
+  const dynamicPlaceholder = uploadContext
+    ? `What would you like to do with ${uploadContext.filename}?`
+    : placeholder || "Describe the PineScript indicator you want...";
+
   function handleSubmit() {
     const trimmed = value.trim();
     if (!trimmed || disabled) return;
-    onSend(trimmed);
+
+    const message = uploadContext
+      ? `[File: ${uploadContext.filename}]\n${trimmed}`
+      : trimmed;
+
+    onSend(message);
     setValue("");
+    if (uploadContext && onDismissUpload) {
+      onDismissUpload();
+    }
   }
 
   function handleKeyDown(e: React.KeyboardEvent) {
@@ -38,27 +63,127 @@ export default function ChatInput({ onSend, disabled, placeholder }: ChatInputPr
     }
   }
 
+  function processFile(file: File) {
+    if (!onUpload) return;
+    const ext = file.name.split(".").pop()?.toLowerCase();
+    if (ext !== "pine" && ext !== "txt") return;
+
+    const reader = new FileReader();
+    reader.onload = (e) => {
+      const code = e.target?.result as string;
+      if (code) {
+        onUpload(code, file.name);
+      }
+    };
+    reader.readAsText(file);
+  }
+
+  function handleFileChange(e: React.ChangeEvent<HTMLInputElement>) {
+    const file = e.target.files?.[0];
+    if (file) processFile(file);
+    // Reset input value so re-uploading the same file works
+    e.target.value = "";
+  }
+
+  function handleDragEnter(e: React.DragEvent) {
+    e.preventDefault();
+    e.stopPropagation();
+    dragCounterRef.current++;
+    if (dragCounterRef.current === 1) {
+      setIsDragging(true);
+    }
+  }
+
+  function handleDragLeave(e: React.DragEvent) {
+    e.preventDefault();
+    e.stopPropagation();
+    dragCounterRef.current--;
+    if (dragCounterRef.current === 0) {
+      setIsDragging(false);
+    }
+  }
+
+  function handleDragOver(e: React.DragEvent) {
+    e.preventDefault();
+    e.stopPropagation();
+  }
+
+  function handleDrop(e: React.DragEvent) {
+    e.preventDefault();
+    e.stopPropagation();
+    dragCounterRef.current = 0;
+    setIsDragging(false);
+
+    const file = e.dataTransfer.files[0];
+    if (file) processFile(file);
+  }
+
   return (
     <div className="px-4 pb-4">
-      <div className="bg-surface border border-border rounded-2xl p-2 flex items-end gap-2 focus-within:border-border-subtle transition-colors">
-        <textarea
-          ref={textareaRef}
-          value={value}
-          onChange={(e) => setValue(e.target.value)}
-          onKeyDown={handleKeyDown}
-          placeholder={placeholder || "Describe the PineScript indicator you want..."}
-          disabled={disabled}
-          rows={1}
-          className="flex-1 bg-transparent text-sm text-text placeholder:text-text-muted resize-none focus:outline-none min-h-[36px] py-2 pl-2 leading-snug"
-        />
+      <div
+        onDragEnter={handleDragEnter}
+        onDragLeave={handleDragLeave}
+        onDragOver={handleDragOver}
+        onDrop={handleDrop}
+        className={`bg-surface border rounded-2xl p-2 flex flex-col gap-2 focus-within:border-border-subtle transition-colors ${
+          isDragging ? "border-primary/50" : "border-border"
+        }`}
+      >
+        {/* File badge */}
+        {uploadContext && (
+          <div className="flex items-center gap-1 px-2">
+            <span className="inline-flex items-center gap-1.5 px-2.5 py-1 rounded-lg bg-primary/10 text-primary text-xs font-medium">
+              {uploadContext.filename}
+              <button
+                type="button"
+                onClick={onDismissUpload}
+                className="hover:text-primary/70 transition-colors"
+              >
+                <X size={12} />
+              </button>
+            </span>
+          </div>
+        )}
 
-        <button
-          onClick={handleSubmit}
-          disabled={!value.trim() || disabled}
-          className="w-9 h-9 flex items-center justify-center rounded-full bg-white text-background hover:bg-text-secondary transition-colors disabled:opacity-30 disabled:cursor-not-allowed shrink-0"
-        >
-          <ArrowUp size={18} />
-        </button>
+        <div className="flex items-end gap-2">
+          {/* Paperclip button */}
+          <button
+            type="button"
+            onClick={() => fileInputRef.current?.click()}
+            disabled={disabled}
+            className="w-9 h-9 flex items-center justify-center rounded-full text-text-muted hover:text-text-secondary transition-colors disabled:opacity-30 disabled:cursor-not-allowed shrink-0"
+          >
+            <Paperclip size={18} />
+          </button>
+
+          {/* Hidden file input */}
+          <input
+            ref={fileInputRef}
+            type="file"
+            accept=".pine,.txt"
+            onChange={handleFileChange}
+            className="hidden"
+          />
+
+          <textarea
+            ref={textareaRef}
+            value={value}
+            onChange={(e) => setValue(e.target.value)}
+            onKeyDown={handleKeyDown}
+            placeholder={dynamicPlaceholder}
+            disabled={disabled}
+            rows={1}
+            className="flex-1 bg-transparent text-sm text-text placeholder:text-text-muted resize-none focus:outline-none min-h-[36px] py-2 leading-snug"
+          />
+
+          <button
+            onClick={handleSubmit}
+            disabled={!value.trim() || disabled}
+            className="w-9 h-9 flex items-center justify-center rounded-full bg-white text-background hover:bg-text-secondary transition-colors disabled:opacity-30 disabled:cursor-not-allowed shrink-0"
+          >
+            <ArrowUp size={18} />
+          </button>
+        </div>
       </div>
       <p className="text-[11px] text-text-muted text-center mt-2">
         AI-generated code may contain errors. Always backtest.

--- a/src/components/editor/DiffView.tsx
+++ b/src/components/editor/DiffView.tsx
@@ -1,0 +1,165 @@
+"use client";
+
+import { useMemo } from "react";
+import { Check, X, GitCompareArrows } from "lucide-react";
+
+interface DiffViewProps {
+  originalCode: string;
+  correctedCode: string;
+  onAccept: () => void;
+  onReject: () => void;
+}
+
+interface DiffLine {
+  type: "add" | "remove" | "unchanged";
+  content: string;
+  oldLineNum?: number;
+  newLineNum?: number;
+}
+
+function computeDiff(oldText: string, newText: string): DiffLine[] {
+  const oldLines = oldText.split("\n");
+  const newLines = newText.split("\n");
+  const m = oldLines.length;
+  const n = newLines.length;
+
+  // LCS dynamic programming table
+  const dp: number[][] = Array.from({ length: m + 1 }, () =>
+    new Array(n + 1).fill(0)
+  );
+  for (let i = 1; i <= m; i++) {
+    for (let j = 1; j <= n; j++) {
+      dp[i][j] =
+        oldLines[i - 1] === newLines[j - 1]
+          ? dp[i - 1][j - 1] + 1
+          : Math.max(dp[i - 1][j], dp[i][j - 1]);
+    }
+  }
+
+  // Backtrack to build diff
+  const result: DiffLine[] = [];
+  let i = m;
+  let j = n;
+  let oldNum = m;
+  let newNum = n;
+
+  while (i > 0 || j > 0) {
+    if (i > 0 && j > 0 && oldLines[i - 1] === newLines[j - 1]) {
+      result.unshift({
+        type: "unchanged",
+        content: oldLines[i - 1],
+        oldLineNum: oldNum--,
+        newLineNum: newNum--,
+      });
+      i--;
+      j--;
+    } else if (j > 0 && (i === 0 || dp[i][j - 1] >= dp[i - 1][j])) {
+      result.unshift({
+        type: "add",
+        content: newLines[j - 1],
+        newLineNum: newNum--,
+      });
+      j--;
+    } else {
+      result.unshift({
+        type: "remove",
+        content: oldLines[i - 1],
+        oldLineNum: oldNum--,
+      });
+      i--;
+    }
+  }
+
+  // Fix line numbers (they were computed in reverse)
+  let oNum = 1;
+  let nNum = 1;
+  for (const line of result) {
+    if (line.type === "unchanged") {
+      line.oldLineNum = oNum++;
+      line.newLineNum = nNum++;
+    } else if (line.type === "remove") {
+      line.oldLineNum = oNum++;
+    } else {
+      line.newLineNum = nNum++;
+    }
+  }
+
+  return result;
+}
+
+export default function DiffView({
+  originalCode,
+  correctedCode,
+  onAccept,
+  onReject,
+}: DiffViewProps) {
+  const diffLines = useMemo(
+    () => computeDiff(originalCode, correctedCode),
+    [originalCode, correctedCode]
+  );
+
+  const addCount = diffLines.filter((l) => l.type === "add").length;
+  const removeCount = diffLines.filter((l) => l.type === "remove").length;
+
+  return (
+    <div className="border-b border-border bg-surface">
+      {/* Header */}
+      <div className="flex items-center justify-between px-3 py-2 border-b border-border">
+        <div className="flex items-center gap-2 text-xs">
+          <GitCompareArrows size={14} className="text-primary" />
+          <span className="font-medium text-text">Auto-correction diff</span>
+          <span className="text-emerald-400">+{addCount}</span>
+          <span className="text-red-400">-{removeCount}</span>
+        </div>
+        <div className="flex items-center gap-1.5">
+          <button
+            onClick={onReject}
+            className="flex items-center gap-1 px-2.5 py-1 rounded-md text-xs text-text-dim hover:text-accent-error hover:bg-accent-error/10 transition-colors"
+          >
+            <X size={12} />
+            Reject
+          </button>
+          <button
+            onClick={onAccept}
+            className="flex items-center gap-1 px-2.5 py-1 rounded-md text-xs font-medium bg-primary/10 text-primary hover:bg-primary/20 transition-colors"
+          >
+            <Check size={12} />
+            Accept
+          </button>
+        </div>
+      </div>
+
+      {/* Diff lines */}
+      <div className="max-h-64 overflow-y-auto font-mono text-xs">
+        {diffLines.map((line, idx) => (
+          <div
+            key={idx}
+            className={`flex ${
+              line.type === "add"
+                ? "bg-emerald-500/8 text-emerald-300"
+                : line.type === "remove"
+                  ? "bg-red-500/8 text-red-300"
+                  : "text-text-dim"
+            }`}
+          >
+            {/* Line numbers */}
+            <span className="w-10 shrink-0 text-right pr-2 py-px text-text-muted select-none border-r border-border">
+              {line.oldLineNum ?? ""}
+            </span>
+            <span className="w-10 shrink-0 text-right pr-2 py-px text-text-muted select-none border-r border-border">
+              {line.newLineNum ?? ""}
+            </span>
+            {/* Indicator */}
+            <span className="w-5 shrink-0 text-center py-px select-none">
+              {line.type === "add" ? "+" : line.type === "remove" ? "-" : " "}
+            </span>
+            {/* Content */}
+            <span className="flex-1 py-px pr-3 whitespace-pre overflow-x-auto">
+              {line.content}
+            </span>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/components/editor/EditorPanel.tsx
+++ b/src/components/editor/EditorPanel.tsx
@@ -3,14 +3,38 @@
 import { useRef, useEffect, useCallback, useState } from "react";
 import { EditorView, keymap, lineNumbers } from "@codemirror/view";
 import { EditorState } from "@codemirror/state";
-import { defaultKeymap, history, historyKeymap } from "@codemirror/commands";
+import {
+  defaultKeymap,
+  history,
+  historyKeymap,
+  undo,
+  redo,
+} from "@codemirror/commands";
 import { bracketMatching, foldGutter } from "@codemirror/language";
-import { Copy, Check, Save, Download, Trash2 } from "lucide-react";
+import {
+  Copy,
+  Check,
+  Save,
+  Download,
+  Trash2,
+  Undo2,
+  Redo2,
+  Code2,
+  Plus,
+} from "lucide-react";
 import { pineScriptLanguage } from "./pine-language";
 import { pineTheme, pineHighlight } from "./codemirror-theme";
 import ValidationPanel from "./ValidationPanel";
-import type { PineVersion, ValidationResult, StreamStatus } from "@/lib/types";
-import { SCRIPTS_KEY } from "@/lib/types";
+import TabBar from "./TabBar";
+import DiffView from "./DiffView";
+import type {
+  PineVersion,
+  ValidationResult,
+  StreamStatus,
+  EditorTab,
+  CodeSnippet,
+} from "@/lib/types";
+import { SCRIPTS_KEY, SNIPPETS_KEY } from "@/lib/types";
 
 interface EditorPanelProps {
   code: string;
@@ -20,9 +44,51 @@ interface EditorPanelProps {
   onClear: () => void;
   validationResults?: ValidationResult[];
   correctedCode?: string | null;
+  preCorrectCode?: string | null;
   streamStatus?: StreamStatus;
   onFix?: () => void;
+  // Tab management
+  tabs: EditorTab[];
+  activeTabId: string | null;
+  onTabSelect: (tabId: string) => void;
+  onTabClose: (tabId: string) => void;
+  onTabReorder: (tabIds: string[]) => void;
+  // Correction handling
+  onAcceptCorrection?: () => void;
+  onRejectCorrection?: () => void;
 }
+
+const DEFAULT_SNIPPETS: CodeSnippet[] = [
+  {
+    id: "input-block",
+    title: "Input Block",
+    code: `// Input parameters
+length = input.int(14, "Length", minval=1)
+source = input.source(close, "Source")
+mult = input.float(2.0, "Multiplier", minval=0.1, step=0.1)`,
+    createdAt: 0,
+  },
+  {
+    id: "plot-config",
+    title: "Plot Configuration",
+    code: `// Plot
+plot(result, "Result", color=color.new(color.blue, 0), linewidth=2)
+hline(0, "Zero", color=color.gray, linestyle=hline.style_dashed)`,
+    createdAt: 0,
+  },
+  {
+    id: "strategy-entry",
+    title: "Strategy Entry/Exit",
+    code: `// Strategy entry/exit
+if longCondition
+    strategy.entry("Long", strategy.long)
+if shortCondition
+    strategy.entry("Short", strategy.short)
+if exitCondition
+    strategy.close_all()`,
+    createdAt: 0,
+  },
+];
 
 export default function EditorPanel({
   code,
@@ -32,17 +98,58 @@ export default function EditorPanel({
   onClear,
   validationResults = [],
   correctedCode = null,
+  preCorrectCode = null,
   streamStatus,
   onFix,
+  tabs,
+  activeTabId,
+  onTabSelect,
+  onTabClose,
+  onTabReorder,
+  onAcceptCorrection,
+  onRejectCorrection,
 }: EditorPanelProps) {
   const containerRef = useRef<HTMLDivElement>(null);
   const viewRef = useRef<EditorView | null>(null);
   const [copied, setCopied] = useState(false);
   const [saved, setSaved] = useState(false);
+  const [showSnippets, setShowSnippets] = useState(false);
+  const [snippets, setSnippets] = useState<CodeSnippet[]>([]);
+  const snippetRef = useRef<HTMLDivElement>(null);
+
+  // Store EditorState per tab for history persistence
+  const statesRef = useRef<Map<string, EditorState>>(new Map());
+  const prevTabIdRef = useRef<string | null>(null);
 
   const onCodeChangeRef = useRef(onCodeChange);
   onCodeChangeRef.current = onCodeChange;
 
+  // Load user snippets from localStorage
+  useEffect(() => {
+    try {
+      const stored = localStorage.getItem(SNIPPETS_KEY);
+      if (stored) {
+        setSnippets(JSON.parse(stored));
+      }
+    } catch {
+      // Ignore
+    }
+  }, []);
+
+  // Close snippets dropdown on outside click
+  useEffect(() => {
+    function handleClickOutside(e: MouseEvent) {
+      if (snippetRef.current && !snippetRef.current.contains(e.target as Node)) {
+        setShowSnippets(false);
+      }
+    }
+    if (showSnippets) {
+      document.addEventListener("mousedown", handleClickOutside);
+      return () => document.removeEventListener("mousedown", handleClickOutside);
+    }
+  }, [showSnippets]);
+
+  // Initialize CodeMirror
   useEffect(() => {
     if (!containerRef.current) return;
 
@@ -76,12 +183,39 @@ export default function EditorPanel({
     viewRef.current = view;
 
     return () => {
+      // Save state before destroying
+      if (activeTabId && viewRef.current) {
+        statesRef.current.set(activeTabId, viewRef.current.state);
+      }
       view.destroy();
       viewRef.current = null;
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
+  // Handle tab switching — save/restore EditorState for undo/redo persistence
+  useEffect(() => {
+    const view = viewRef.current;
+    if (!view || !activeTabId) return;
+
+    const prevId = prevTabIdRef.current;
+    if (prevId && prevId !== activeTabId) {
+      // Save the outgoing tab's state (preserves undo history)
+      statesRef.current.set(prevId, view.state);
+
+      // Restore the incoming tab's state if we have one
+      const savedState = statesRef.current.get(activeTabId);
+      if (savedState) {
+        view.setState(savedState);
+        prevTabIdRef.current = activeTabId;
+        return; // Don't also run the code sync below
+      }
+    }
+
+    prevTabIdRef.current = activeTabId;
+  }, [activeTabId]);
+
+  // Sync code from props to editor (for external changes like AI generation)
   useEffect(() => {
     const view = viewRef.current;
     if (!view) return;
@@ -93,6 +227,14 @@ export default function EditorPanel({
       });
     }
   }, [code]);
+
+  const handleUndo = useCallback(() => {
+    if (viewRef.current) undo(viewRef.current);
+  }, []);
+
+  const handleRedo = useCallback(() => {
+    if (viewRef.current) redo(viewRef.current);
+  }, []);
 
   const copyCode = useCallback(() => {
     navigator.clipboard.writeText(code);
@@ -114,7 +256,8 @@ export default function EditorPanel({
   }, [code, title]);
 
   const downloadScript = useCallback(() => {
-    const filename = (title || "script").replace(/[^a-z0-9_-]/gi, "_").toLowerCase() + ".pine";
+    const filename =
+      (title || "script").replace(/[^a-z0-9_-]/gi, "_").toLowerCase() + ".pine";
     const blob = new Blob([code], { type: "text/plain" });
     const url = URL.createObjectURL(blob);
     const a = document.createElement("a");
@@ -124,8 +267,61 @@ export default function EditorPanel({
     URL.revokeObjectURL(url);
   }, [code, title]);
 
+  const saveAsSnippet = useCallback(() => {
+    if (!code.trim()) return;
+    const snippet: CodeSnippet = {
+      id: Date.now().toString(),
+      title: title || "Untitled Snippet",
+      code,
+      createdAt: Date.now(),
+    };
+    const updated = [snippet, ...snippets];
+    setSnippets(updated);
+    localStorage.setItem(SNIPPETS_KEY, JSON.stringify(updated));
+    setShowSnippets(false);
+  }, [code, title, snippets]);
+
+  const insertSnippet = useCallback(
+    (snippetCode: string) => {
+      const view = viewRef.current;
+      if (view) {
+        const cursor = view.state.selection.main.head;
+        view.dispatch({
+          changes: { from: cursor, insert: snippetCode },
+        });
+      }
+      setShowSnippets(false);
+    },
+    []
+  );
+
+  const deleteSnippet = useCallback(
+    (snippetId: string) => {
+      const updated = snippets.filter((s) => s.id !== snippetId);
+      setSnippets(updated);
+      localStorage.setItem(SNIPPETS_KEY, JSON.stringify(updated));
+    },
+    [snippets]
+  );
+
+  const handleNewTab = useCallback(() => {
+    onCodeChange("");
+  }, [onCodeChange]);
+
+  const showDiff = correctedCode && preCorrectCode && correctedCode !== preCorrectCode;
+
   return (
     <div className="h-full flex flex-col bg-background border-l border-border">
+      {/* Tab bar */}
+      <TabBar
+        tabs={tabs}
+        activeTabId={activeTabId}
+        onTabSelect={onTabSelect}
+        onTabClose={onTabClose}
+        onTabReorder={onTabReorder}
+        onNewTab={handleNewTab}
+      />
+
       {/* Header */}
       <div className="flex items-center justify-between px-4 py-2.5 border-b border-border bg-surface">
         <div className="flex items-center gap-2.5">
@@ -137,6 +333,96 @@ export default function EditorPanel({
           </span>
         </div>
         <div className="flex items-center gap-1">
+          {/* Undo */}
+          <button
+            onClick={handleUndo}
+            className="w-8 h-8 flex items-center justify-center rounded-md text-text-dim hover:text-text-secondary hover:bg-surface-elevated transition-colors"
+            title="Undo (Ctrl+Z)"
+          >
+            <Undo2 size={15} />
+          </button>
+          {/* Redo */}
+          <button
+            onClick={handleRedo}
+            className="w-8 h-8 flex items-center justify-center rounded-md text-text-dim hover:text-text-secondary hover:bg-surface-elevated transition-colors"
+            title="Redo (Ctrl+Shift+Z)"
+          >
+            <Redo2 size={15} />
+          </button>
+
+          <div className="w-px h-4 bg-border mx-0.5" />
+
+          {/* Snippets dropdown */}
+          <div className="relative" ref={snippetRef}>
+            <button
+              onClick={() => setShowSnippets(!showSnippets)}
+              className="w-8 h-8 flex items-center justify-center rounded-md text-text-dim hover:text-text-secondary hover:bg-surface-elevated transition-colors"
+              title="Code snippets"
+            >
+              <Code2 size={15} />
+            </button>
+            {showSnippets && (
+              <div className="absolute right-0 top-full mt-1 w-64 bg-surface border border-border rounded-lg shadow-xl z-20 overflow-hidden">
+                <div className="px-3 py-2 border-b border-border flex items-center justify-between">
+                  <span className="text-xs font-medium text-text">Snippets</span>
+                  <button
+                    onClick={saveAsSnippet}
+                    className="flex items-center gap-1 text-xs text-primary hover:text-primary/80 transition-colors"
+                  >
+                    <Plus size={10} />
+                    Save current
+                  </button>
+                </div>
+                <div className="max-h-64 overflow-y-auto">
+                  {/* Default snippets */}
+                  {DEFAULT_SNIPPETS.map((s) => (
+                    <button
+                      key={s.id}
+                      onClick={() => insertSnippet(s.code)}
+                      className="w-full text-left px-3 py-2 text-xs text-text-secondary hover:bg-surface-elevated hover:text-text transition-colors border-b border-border/50 last:border-0"
+                    >
+                      <span className="font-medium">{s.title}</span>
+                      <span className="block text-text-dim mt-0.5 truncate font-mono text-[10px]">
+                        {s.code.split("\n")[0]}
+                      </span>
+                    </button>
+                  ))}
+                  {/* User snippets */}
+                  {snippets.map((s) => (
+                    <div
+                      key={s.id}
+                      className="flex items-center border-b border-border/50 last:border-0 hover:bg-surface-elevated transition-colors"
+                    >
+                      <button
+                        onClick={() => insertSnippet(s.code)}
+                        className="flex-1 text-left px-3 py-2 text-xs text-text-secondary hover:text-text"
+                      >
+                        <span className="font-medium">{s.title}</span>
+                        <span className="block text-text-dim mt-0.5 truncate font-mono text-[10px]">
+                          {s.code.split("\n")[0]}
+                        </span>
+                      </button>
+                      <button
+                        onClick={() => deleteSnippet(s.id)}
+                        className="shrink-0 mr-2 w-5 h-5 flex items-center justify-center rounded text-text-dim hover:text-accent-error transition-colors"
+                        title="Delete snippet"
+                      >
+                        <Trash2 size={10} />
+                      </button>
+                    </div>
+                  ))}
+                  {snippets.length === 0 && (
+                    <div className="px-3 py-2 text-xs text-text-dim border-t border-border/50">
+                      No saved snippets yet
+                    </div>
+                  )}
+                </div>
+              </div>
+            )}
+          </div>
+
+          <div className="w-px h-4 bg-border mx-0.5" />
+
           <button
             onClick={copyCode}
             className="w-8 h-8 flex items-center justify-center rounded-md text-text-dim hover:text-text-secondary hover:bg-surface-elevated transition-colors"
@@ -169,12 +455,22 @@ export default function EditorPanel({
           <button
             onClick={onClear}
             className="w-8 h-8 flex items-center justify-center rounded-md text-text-dim hover:text-accent-error hover:bg-accent-error/10 transition-colors"
-            title="Clear editor"
+            title="Close tab"
           >
             <Trash2 size={15} />
           </button>
         </div>
       </div>
+
+      {/* Diff view for auto-corrections */}
+      {showDiff && onAcceptCorrection && onRejectCorrection && (
+        <DiffView
+          originalCode={preCorrectCode}
+          correctedCode={correctedCode}
+          onAccept={onAcceptCorrection}
+          onReject={onRejectCorrection}
+        />
+      )}
 
       {/* CodeMirror container */}
       <div ref={containerRef} className="flex-1 overflow-auto" />

--- a/src/components/editor/TabBar.tsx
+++ b/src/components/editor/TabBar.tsx
@@ -1,0 +1,141 @@
+"use client";
+
+import { useRef, useState, useCallback } from "react";
+import { X, Plus, AlertTriangle } from "lucide-react";
+import type { EditorTab } from "@/lib/types";
+
+interface TabBarProps {
+  tabs: EditorTab[];
+  activeTabId: string | null;
+  onTabSelect: (tabId: string) => void;
+  onTabClose: (tabId: string) => void;
+  onTabReorder: (tabIds: string[]) => void;
+  onNewTab: () => void;
+}
+
+const MAX_TABS = 10;
+
+export default function TabBar({
+  tabs,
+  activeTabId,
+  onTabSelect,
+  onTabClose,
+  onTabReorder,
+  onNewTab,
+}: TabBarProps) {
+  const [dragTabId, setDragTabId] = useState<string | null>(null);
+  const [dragOverTabId, setDragOverTabId] = useState<string | null>(null);
+  const [showMaxWarning, setShowMaxWarning] = useState(false);
+  const scrollRef = useRef<HTMLDivElement>(null);
+
+  const handleDragStart = useCallback((e: React.DragEvent, tabId: string) => {
+    setDragTabId(tabId);
+    e.dataTransfer.effectAllowed = "move";
+    e.dataTransfer.setData("text/plain", tabId);
+  }, []);
+
+  const handleDragOver = useCallback((e: React.DragEvent, tabId: string) => {
+    e.preventDefault();
+    e.dataTransfer.dropEffect = "move";
+    setDragOverTabId(tabId);
+  }, []);
+
+  const handleDrop = useCallback((e: React.DragEvent, targetTabId: string) => {
+    e.preventDefault();
+    setDragTabId(null);
+    setDragOverTabId(null);
+
+    const sourceTabId = e.dataTransfer.getData("text/plain");
+    if (!sourceTabId || sourceTabId === targetTabId) return;
+
+    const tabIds = tabs.map(t => t.id);
+    const sourceIdx = tabIds.indexOf(sourceTabId);
+    const targetIdx = tabIds.indexOf(targetTabId);
+    if (sourceIdx === -1 || targetIdx === -1) return;
+
+    tabIds.splice(sourceIdx, 1);
+    tabIds.splice(targetIdx, 0, sourceTabId);
+    onTabReorder(tabIds);
+  }, [tabs, onTabReorder]);
+
+  const handleDragEnd = useCallback(() => {
+    setDragTabId(null);
+    setDragOverTabId(null);
+  }, []);
+
+  const handleNewTab = useCallback(() => {
+    if (tabs.length >= MAX_TABS) {
+      setShowMaxWarning(true);
+      setTimeout(() => setShowMaxWarning(false), 3000);
+      return;
+    }
+    onNewTab();
+  }, [tabs.length, onNewTab]);
+
+  if (tabs.length === 0) return null;
+
+  return (
+    <div className="relative border-b border-border bg-background">
+      <div
+        ref={scrollRef}
+        className="flex items-center overflow-x-auto scrollbar-none"
+      >
+        {tabs.map((tab) => {
+          const isActive = tab.id === activeTabId;
+          const isDragging = tab.id === dragTabId;
+          const isDragOver = tab.id === dragOverTabId;
+
+          return (
+            <div
+              key={tab.id}
+              draggable
+              onDragStart={(e) => handleDragStart(e, tab.id)}
+              onDragOver={(e) => handleDragOver(e, tab.id)}
+              onDrop={(e) => handleDrop(e, tab.id)}
+              onDragEnd={handleDragEnd}
+              onClick={() => onTabSelect(tab.id)}
+              className={`group flex items-center gap-1.5 px-3 py-1.5 text-xs cursor-pointer border-r border-border select-none shrink-0 transition-colors ${
+                isActive
+                  ? "bg-surface text-text border-b-2 border-b-primary"
+                  : "bg-background text-text-dim hover:text-text-secondary hover:bg-surface/50"
+              } ${isDragging ? "opacity-40" : ""} ${
+                isDragOver ? "border-l-2 border-l-primary" : ""
+              }`}
+            >
+              <span className="truncate max-w-[120px]" title={tab.title}>
+                {tab.title || "Untitled"}
+              </span>
+              <button
+                onClick={(e) => {
+                  e.stopPropagation();
+                  onTabClose(tab.id);
+                }}
+                className="shrink-0 w-4 h-4 flex items-center justify-center rounded opacity-0 group-hover:opacity-100 hover:bg-surface-elevated transition-all"
+                title="Close tab"
+              >
+                <X size={10} />
+              </button>
+            </div>
+          );
+        })}
+
+        {/* New tab button */}
+        <button
+          onClick={handleNewTab}
+          className="shrink-0 w-7 h-7 flex items-center justify-center text-text-dim hover:text-text-secondary hover:bg-surface/50 transition-colors"
+          title={tabs.length >= MAX_TABS ? `Max ${MAX_TABS} tabs` : "New tab"}
+        >
+          <Plus size={12} />
+        </button>
+      </div>
+
+      {/* Max tabs warning */}
+      {showMaxWarning && (
+        <div className="absolute top-full left-0 right-0 z-10 flex items-center gap-2 px-3 py-1.5 bg-amber-500/10 border-b border-amber-500/20 text-xs text-amber-400">
+          <AlertTriangle size={12} />
+          Maximum {MAX_TABS} tabs reached. Close a tab to open a new one.
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -49,6 +49,9 @@ export interface ChatState {
   error: string | null;
   validationResults: ValidationResult[];
   correctedCode: string | null;
+  tabs: EditorTab[];
+  activeTabId: string | null;
+  preCorrectCode: string | null;
 }
 
 export const DEFAULT_SETTINGS: Settings = {
@@ -107,6 +110,22 @@ export interface ScriptSession {
 }
 
 export const SESSIONS_KEY = "pinescript-ai-sessions";
+export const TABS_KEY = "pinescript-ai-tabs";
+export const SNIPPETS_KEY = "pinescript-ai-snippets";
+
+export interface EditorTab {
+  id: string;
+  title: string;
+  code: string;
+  createdAt: number;
+}
+
+export interface CodeSnippet {
+  id: string;
+  title: string;
+  code: string;
+  createdAt: number;
+}
 
 export interface ReviewIssue {
   severity: "error" | "warning" | "info";


### PR DESCRIPTION
## Summary
- **Multi-tab editor**: TabBar component with drag-to-reorder, close buttons, max 10 tabs with warning, and localStorage persistence. Each AI generation creates a new tab; incremental streaming updates the active tab.
- **Diff view for auto-corrections**: LCS-based inline diff shows added/removed lines with accept/reject buttons. Corrections no longer auto-overwrite — users see what changed first.
- **Undo/redo buttons**: Toolbar buttons wired to CodeMirror `undo`/`redo` commands. EditorState preserved per tab across tab switches so history persists.
- **Code snippets**: Dropdown with 3 built-in templates (input block, plot config, strategy entry/exit) plus save/insert/delete custom snippets stored in localStorage.

## Files Changed
- `src/lib/types.ts` — Added `EditorTab`, `CodeSnippet`, `TABS_KEY`, `SNIPPETS_KEY`; extended `ChatState` with `tabs`, `activeTabId`, `preCorrectCode`
- `src/hooks/useChat.ts` — Extended reducer with `CLOSE_TAB`, `SET_ACTIVE_TAB`, `REORDER_TABS`, `LOAD_TABS`, `ACCEPT_CORRECTION`, `REJECT_CORRECTION`; modified `SET_CODE` to create/update tabs; tab localStorage persistence; stopped auto-applying corrections for diff view
- `src/components/editor/TabBar.tsx` — **New**: Tab bar with HTML5 drag-to-reorder, close, new tab button, max 10 warning
- `src/components/editor/DiffView.tsx` — **New**: Inline diff viewer with LCS algorithm, line numbers, accept/reject
- `src/components/editor/EditorPanel.tsx` — Integrated TabBar, DiffView, undo/redo buttons, snippets dropdown; added per-tab EditorState persistence for undo history
- `src/app/chat/page.tsx` — Wired new props from `useChat` to `EditorPanel`

## Test plan
- [ ] Generate code → verify new tab created in tab bar
- [ ] Generate again → verify second tab appears
- [ ] Click between tabs → verify code switches and undo history persists per tab
- [ ] Close a tab → verify nearest tab activates
- [ ] Drag tabs to reorder → verify order persists
- [ ] Refresh page → verify tabs persist from localStorage
- [ ] Trigger auto-correction → verify diff view appears with accept/reject
- [ ] Accept correction → verify code updates
- [ ] Reject correction → verify original code kept
- [ ] Click undo/redo buttons → verify they work
- [ ] Open snippets dropdown → verify built-in templates appear
- [ ] Save current code as snippet → verify it appears in dropdown
- [ ] Insert a snippet → verify it inserts at cursor
- [ ] Open 10 tabs, try to add 11th → verify warning appears

Closes #9

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * File upload with drag-and-drop support for seamless code import
  * Multi-tab editor enabling work across multiple files simultaneously
  * Undo/Redo functionality in the editor for improved workflow
  * Code snippets system to save and insert reusable code blocks
  * Auto-correction diff viewer with Accept/Reject actions for code improvements

<!-- end of auto-generated comment: release notes by coderabbit.ai -->